### PR TITLE
html escape archive name to prevent warning

### DIFF
--- a/mcomix/main_window.py
+++ b/mcomix/main_window.py
@@ -2,6 +2,7 @@
 
 import shutil
 from pathlib import Path
+from html import escape
 
 from gi.repository import GLib, Gdk, Gtk
 from send2trash import send2trash
@@ -830,7 +831,7 @@ class MainWindow(Gtk.ApplicationWindow):
             dialog.set_should_remember_choice(
                 'delete-opend-file',
                 (Gtk.ResponseType.OK,))
-            dialog.set_text(f'Trash Selected File: "{current_file.name}"?')
+            dialog.set_text(f'Trash Selected File: "{escape(current_file.name)}"?')
             result = dialog.run()
             if result != Gtk.ResponseType.OK:
                 return None


### PR DESCRIPTION
Gtk use html rendering. 
  When a file has an "&" in its name it raises the following error:
(mcomixstarter.py:30250): Gtk-WARNING **: Failed to set text '<span weight="bold" size="larger">Trash Selected File: "....&.....cbz"?</span>' from markup due to error parsing markup: Error on line 1: Entity did not end with a semicolon; most likely you used an ampersand character without intending to start an entity — escape ampersand as &amp;